### PR TITLE
Default Plugin Support

### DIFF
--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -58,7 +58,7 @@ export class Table extends ClassifiedElement {
     public plugins?: Array<ColumnPlugin>
 
     @property({ attribute: 'installed-plugins', type: Array })
-    public installedPlugins: Record<string, PluginWorkspaceInstallationId | undefined> = {}
+    public installedPlugins?: Record<string, PluginWorkspaceInstallationId | undefined>
 
     @state()
     protected rows: Array<RowAsRecord> = []
@@ -283,8 +283,10 @@ export class Table extends ClassifiedElement {
     }
 
     private _onColumnPluginDeactivated({ column }: ColumnPluginDeactivatedEvent) {
-        delete this.installedPlugins[column]
-        this.requestUpdate('installedPlugins')
+        if (this.installedPlugins) {
+            delete this.installedPlugins[column]
+            this.requestUpdate('installedPlugins')
+        }
     }
 
     private _onColumnResized({ delta }: ResizeEvent) {
@@ -420,7 +422,7 @@ export class Table extends ClassifiedElement {
                                               const defaultPlugin = this.plugins?.find(
                                                   ({ id }) => id === this.installedPlugins?.[name]?.plugin_installation_id
                                               )
-                                              const plugin = installedPlugin ? installedPlugin : defaultPlugin
+                                              const plugin = installedPlugin ?? defaultPlugin
                                               return html`
                                                   <!-- TODO @johnny remove separate-cells and instead rely on css variables to suppress borders -->
                                                   <!-- TODO @caleb & johnny move plugins to support the new installedPlugins variable -->

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -412,35 +412,43 @@ export class Table extends ClassifiedElement {
                                       ${repeat(
                                           this.visibleColumns,
                                           ({ name }) => name, // use the column name as the unique identifier for each entry in this row
-                                          ({ name }, idx) => html`
-                                              <!-- TODO @johnny remove separate-cells and instead rely on css variables to suppress borders -->
-                                              <!-- TODO @caleb & johnny move plugins to support the new installedPlugins variable -->
-                                              <outerbase-td
-                                                  .position=${{ row: id, column: name }}
-                                                  value=${values[name] ?? ''}
-                                                  original-value=${originalValues[name]}
-                                                  left-distance-to-viewport=${this.distanceToLeftViewport}
-                                                  table-bounding-rect="${tableBoundingRect}"
-                                                  theme=${this.theme}
-                                                  .plugin=${this.plugins?.find(
-                                                      ({ id }) => id === this.installedPlugins?.[name]?.plugin_installation_id
-                                                  )}
-                                                  ?separate-cells=${true}
-                                                  ?draw-right-border=${true}
-                                                  ?bottom-border=${true}
-                                                  ?outter-border=${this.outterBorder}
-                                                  ?is-last-row=${rowIndex === this.rows.length - 1}
-                                                  ?is-last-column=${idx === this.visibleColumns.length - 1}
-                                                  ?menu=${!this.isNonInteractive}
-                                                  ?selectable-text=${this.isNonInteractive}
-                                                  ?interactive=${!this.isNonInteractive}
-                                                  ?hide-dirt=${isNew}
-                                                  @cell-updated=${() => {
-                                                      this.dispatchEvent(new RowUpdatedEvent({ id, values, originalValues, isNew }))
-                                                  }}
-                                              >
-                                              </outerbase-td>
-                                          `
+                                          ({ name }, idx) => {
+                                              const installedPlugin = this.plugins?.find(
+                                                  ({ pluginWorkspaceId }) =>
+                                                      pluginWorkspaceId === this.installedPlugins?.[name]?.plugin_workspace_id
+                                              )
+                                              const defaultPlugin = this.plugins?.find(
+                                                  ({ id }) => id === this.installedPlugins?.[name]?.plugin_installation_id
+                                              )
+                                              const plugin = installedPlugin ? installedPlugin : defaultPlugin
+                                              return html`
+                                                  <!-- TODO @johnny remove separate-cells and instead rely on css variables to suppress borders -->
+                                                  <!-- TODO @caleb & johnny move plugins to support the new installedPlugins variable -->
+                                                  <outerbase-td
+                                                      .position=${{ row: id, column: name }}
+                                                      value=${values[name] ?? ''}
+                                                      original-value=${originalValues[name]}
+                                                      left-distance-to-viewport=${this.distanceToLeftViewport}
+                                                      table-bounding-rect="${tableBoundingRect}"
+                                                      theme=${this.theme}
+                                                      .plugin=${plugin}
+                                                      ?separate-cells=${true}
+                                                      ?draw-right-border=${true}
+                                                      ?bottom-border=${true}
+                                                      ?outter-border=${this.outterBorder}
+                                                      ?is-last-row=${rowIndex === this.rows.length - 1}
+                                                      ?is-last-column=${idx === this.visibleColumns.length - 1}
+                                                      ?menu=${!this.isNonInteractive}
+                                                      ?selectable-text=${this.isNonInteractive}
+                                                      ?interactive=${!this.isNonInteractive}
+                                                      ?hide-dirt=${isNew}
+                                                      @cell-updated=${() => {
+                                                          this.dispatchEvent(new RowUpdatedEvent({ id, values, originalValues, isNew }))
+                                                      }}
+                                                  >
+                                                  </outerbase-td>
+                                              `
+                                          }
                                       )}
                                   </outerbase-tr>`
                                 : null

--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -127,8 +127,9 @@ export class TH extends MutableElement {
         super.willUpdate(_changedProperties)
 
         if (_changedProperties.has('plugins')) {
+            const withoutDefault = this.plugins.filter((p) => !p.isDefault) ?? []
             this._pluginOptions =
-                this.plugins?.map((plugin) => ({
+                withoutDefault.map((plugin) => ({
                     label: plugin.displayName,
                     value: plugin.tagName,
                 })) ?? []

--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -144,7 +144,7 @@ export class TH extends MutableElement {
 
     protected override render() {
         const name = this.originalValue ?? this.value
-        const hasPlugin = typeof this.installedPlugins?.[name] !== 'undefined'
+        const hasPlugin = typeof this.installedPlugins?.[name] !== 'undefined' && !this.installedPlugins?.[name]?.isDefaultPlugin
         const options = this.dirty
             ? [
                   ...this.options,

--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -55,7 +55,7 @@ export class TH extends MutableElement {
     public override value = ''
 
     @property({ attribute: 'plugins', type: Array })
-    public plugins: Array<ColumnPlugin> = []
+    public plugins?: Array<ColumnPlugin>
 
     @property({ attribute: 'installed-plugins', type: Object })
     public installedPlugins: Record<string, PluginWorkspaceInstallationId | undefined> = {}
@@ -127,7 +127,7 @@ export class TH extends MutableElement {
         super.willUpdate(_changedProperties)
 
         if (_changedProperties.has('plugins')) {
-            const withoutDefault = this.plugins.filter((p) => !p.isDefault) ?? []
+            const withoutDefault = this.plugins?.filter((p) => !p.isDefault) ?? []
             this._pluginOptions =
                 withoutDefault.map((plugin) => ({
                     label: plugin.displayName,
@@ -248,7 +248,7 @@ export class TH extends MutableElement {
         const columnName = this.originalValue ?? this.value
 
         // handle (potential) plugin selection
-        const plugin = this.plugins.find(({ tagName }) => event.value === tagName)
+        const plugin = this.plugins?.find(({ tagName }) => event.value === tagName)
         if (plugin) {
             return this.dispatchEvent(new ColumnPluginActivatedEvent(columnName, { ...plugin, columnName: this.value }))
         }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -44,16 +44,7 @@ const columns = Object.keys(rows[0].values).map((name) => ({ name }))
             <h1 class="font-bold text-xl">Static</h1>
             <div class="bg-white dark:bg-black inline-block">
                 <!-- @ts-ignore Astro doesn't seem to understand some of the params being passed -->
-                <OuterbaseTable
-                    client:only="lit"
-                    installed-plugins={JSON.stringify({})}
-                    plugins={[]}
-                    schema={{ columns }}
-                    data={rows}
-                    keyboard-shortcuts
-                    selectable-rows
-                    outter-border
-                />
+                <OuterbaseTable client:only="lit" schema={{ columns }} data={rows} keyboard-shortcuts selectable-rows outter-border />
             </div>
 
             <h1 class="font-bold text-xl mt-8">SSR w/ Hydration</h1>

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,7 @@ export type ColumnPlugin = {
 export type PluginWorkspaceInstallationId = {
     plugin_workspace_id: string
     plugin_installation_id: string
+    isDefaultPlugin?: boolean
 }
 
 export enum PluginEvent {

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,7 @@ export type PluginWorkspaceInstallationId = {
     plugin_workspace_id: string
     plugin_installation_id: string
     isDefaultPlugin?: boolean
+    supportingAttributes: string
 }
 
 export enum PluginEvent {


### PR DESCRIPTION
If there is a default plugin for a specific cell, it shouldn't be removable. This pull request allows you to ensure that if you have a default plugin, you can't "remove plugin"
<img width="223" alt="image" src="https://github.com/outerbase/starboard/assets/36182383/1728a2a3-da5b-4307-9303-7084661588ef">
