### PR TITLE
Support attributes

### DIFF
--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -88,6 +88,9 @@ export class Table extends ClassifiedElement {
     @property({ attribute: 'theme', type: String })
     public theme = Theme.light
 
+    @property({ attribute: 'plugin-attributes', type: String })
+    public pluginAttributes: String = ''
+
     @state()
     private _height?: number
 
@@ -423,6 +426,7 @@ export class Table extends ClassifiedElement {
                                                   ({ id }) => id === this.installedPlugins?.[name]?.plugin_installation_id
                                               )
                                               const plugin = installedPlugin ?? defaultPlugin
+
                                               return html`
                                                   <!-- TODO @johnny remove separate-cells and instead rely on css variables to suppress borders -->
                                                   <!-- TODO @caleb & johnny move plugins to support the new installedPlugins variable -->
@@ -434,6 +438,7 @@ export class Table extends ClassifiedElement {
                                                       table-bounding-rect="${tableBoundingRect}"
                                                       theme=${this.theme}
                                                       .plugin=${plugin}
+                                                      plugin-attributes=${this.installedPlugins?.[name]?.supportingAttributes ?? ''}
                                                       ?separate-cells=${true}
                                                       ?draw-right-border=${true}
                                                       ?bottom-border=${true}

--- a/src/components/table/td.ts
+++ b/src/components/table/td.ts
@@ -162,7 +162,7 @@ export class TableData extends MutableElement {
         if (this.plugin) {
             const { config, tagName, metadata } = this.plugin
             const pluginAsString = unsafeHTML(
-                `<${tagName} cellvalue=${this.value} cat="dog" configuration=${config} ${this.pluginAttributes}></${tagName}>`
+                `<${tagName} cellvalue=${this.value} configuration=${config} ${this.pluginAttributes}></${tagName}>`
             )
             cellContents = html`${pluginAsString}`
 
@@ -170,7 +170,7 @@ export class TableData extends MutableElement {
                 cellEditorContents = unsafeHTML(
                     `<${tagName.replace('outerbase-plugin-cell', 'outerbase-plugin-editor')} cellvalue=${
                         this.value
-                    } configuration=${config} carpet="ji" ${this.pluginAttributes}></${tagName}>`
+                    } configuration=${config} ${this.pluginAttributes}></${tagName}>`
                 )
             }
         } else {

--- a/src/components/table/td.ts
+++ b/src/components/table/td.ts
@@ -37,6 +37,9 @@ export class TableData extends MutableElement {
         }
     }
 
+    @property({ attribute: 'plugin-attributes', type: String })
+    public pluginAttributes: String = ''
+
     // allows, for example, <outerbase-td max-width="max-w-xl" />
     @property({ type: String, attribute: 'max-width' })
     public maxWidth: string = ''
@@ -159,7 +162,7 @@ export class TableData extends MutableElement {
         if (this.plugin) {
             const { config, tagName, metadata } = this.plugin
             const pluginAsString = unsafeHTML(
-                `<${tagName} cellvalue=${this.value} configuration=${config} metadata=${metadata}></${tagName}>`
+                `<${tagName} cellvalue=${this.value} cat="dog" configuration=${config} ${this.pluginAttributes}></${tagName}>`
             )
             cellContents = html`${pluginAsString}`
 
@@ -167,7 +170,7 @@ export class TableData extends MutableElement {
                 cellEditorContents = unsafeHTML(
                     `<${tagName.replace('outerbase-plugin-cell', 'outerbase-plugin-editor')} cellvalue=${
                         this.value
-                    } configuration=${config} metadata=${metadata}></${tagName}>`
+                    } configuration=${config} carpet="ji" ${this.pluginAttributes}></${tagName}>`
                 )
             }
         } else {
@@ -205,7 +208,7 @@ export class TableData extends MutableElement {
                         ?selectable-text=${!this.isInteractive}
                         @menu-selection=${this.onMenuSelection}
                         ><span class=${darkClass}>${cellContents}</span
-                        ><span class="absolute top-1">${cellEditorContents}</span></outerbase-td-menu
+                        ><span class="absolute top-8">${cellEditorContents}</span></outerbase-td-menu
                     >`
     }
 


### PR DESCRIPTION
When you're creating a plugin, you have the ability to select certain attributes so that your plugin has more metadata it can reference. This pull request adds the ability to give your web components attributes that are specified when you create a plugin. Below is an example of the plugin receiving some attributes and displaying it on itself.

<img width="304" alt="image" src="https://github.com/outerbase/starboard/assets/36182383/486772f0-ca9f-4496-8cf1-daa4fc68e47f">
