### PR TITLE
prevent column sorting while resizing

### DIFF
--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -213,11 +213,12 @@ export class TH extends MutableElement {
     protected onClick(event: MouseEvent) {
         const path = event.composedPath() as Array<HTMLElement>
         const hasTrigger = path.some((p) => p.getAttribute?.('id') === 'trigger')
+        const isNotResizer = !path.some((p) => p.tagName?.toLowerCase() === 'column-resizer')
         const name = this.originalValue ?? this.value ?? ''
 
         // we check for the 'trigger' which is the button inside this cell
         // if it's being clicked we don't want to interfere with it's operation / trigger sorting
-        if (!hasTrigger && name) {
+        if (!hasTrigger && name && isNotResizer) {
             this.dispatchEvent(
                 new ColumnUpdatedEvent({
                     name,

--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -213,8 +213,8 @@ export class TH extends MutableElement {
     protected onClick(event: MouseEvent) {
         const path = event.composedPath() as Array<HTMLElement>
         const hasTrigger = path.some((p) => p.getAttribute?.('id') === 'trigger')
-        const isNotResizer = !path.some((p) => p.tagName?.toLowerCase() === 'column-resizer')
         const name = this.originalValue ?? this.value
+        const isNotResizer = !path.some((p) => p.tagName?.toLowerCase() === 'column-resizer')
 
         // we check for the 'trigger' which is the button inside this cell
         // if it's being clicked we don't want to interfere with it's operation / trigger sorting

--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -214,7 +214,7 @@ export class TH extends MutableElement {
         const path = event.composedPath() as Array<HTMLElement>
         const hasTrigger = path.some((p) => p.getAttribute?.('id') === 'trigger')
         const isNotResizer = !path.some((p) => p.tagName?.toLowerCase() === 'column-resizer')
-        const name = this.originalValue ?? this.value ?? ''
+        const name = this.originalValue ?? this.value
 
         // we check for the 'trigger' which is the button inside this cell
         // if it's being clicked we don't want to interfere with it's operation / trigger sorting


### PR DESCRIPTION
`path` contains all of the elements (hierarchy) that are part of the `click`. If that hierarchy includes `<column-resizer />` then abort sorting as that means the user is clicking on the resizer handle which is contained insider the header which has this onClicker attached