### PR TITLE
use less instance methods

### DIFF
--- a/src/components/check-box.ts
+++ b/src/components/check-box.ts
@@ -32,10 +32,12 @@ export class CustomCheckbox extends LitElement {
             this.toggleCheckbox(event)
         }
     }
+
     connectedCallback(): void {
         super.connectedCallback()
         this.addEventListener('keydown', this.onKeyDown)
     }
+
     disconnectedCallback(): void {
         super.disconnectedCallback()
         this.removeEventListener('keydown', this.onKeyDown)

--- a/src/components/menu/cell-menu.ts
+++ b/src/components/menu/cell-menu.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit'
-import { customElement, property } from 'lit/decorators.js'
+import { customElement } from 'lit/decorators.js'
 import { classMap } from 'lit/directives/class-map.js'
 
 import { Theme } from '../../types.js'
@@ -7,10 +7,6 @@ import { Menu } from './index.js'
 
 @customElement('outerbase-td-menu')
 export class CellMenu extends Menu {
-    // JOHNNY this is unused
-    @property({ attribute: 'selectable-text', type: Boolean })
-    public selectableText = false
-
     protected override get menuPositionClasses() {
         const isRenderingInBrowser = typeof window !== 'undefined'
         if (!isRenderingInBrowser) return ''

--- a/src/components/menu/cell-menu.ts
+++ b/src/components/menu/cell-menu.ts
@@ -7,9 +7,6 @@ import { Menu } from './index.js'
 
 @customElement('outerbase-td-menu')
 export class CellMenu extends Menu {
-    @property({ attribute: 'menu', type: Boolean })
-    public hasMenu = false
-
     // JOHNNY this is unused
     @property({ attribute: 'selectable-text', type: Boolean })
     public selectableText = false

--- a/src/components/mutable-element.ts
+++ b/src/components/mutable-element.ts
@@ -182,6 +182,9 @@ export class MutableElement extends ClassifiedElement {
     @property({ attribute: 'is-editing', type: Boolean })
     public isEditing = false
 
+    @property({ attribute: 'menu', type: Boolean })
+    public hasMenu = false
+
     public override updated(changedProps: PropertyValues<this>) {
         super.updated(changedProps)
 

--- a/src/components/mutable-element.ts
+++ b/src/components/mutable-element.ts
@@ -25,6 +25,86 @@ export const BOOLEAN_TYPES = ['Boolean', 'Bit'].map((s) => s.toLowerCase())
 export const JSON_TYPES = ['JSON', 'JSONB', 'ARRAY'].map((s) => s.toLowerCase())
 
 export class MutableElement extends ClassifiedElement {
+    static moveFocusToNextRow(target: HTMLElement) {
+        const parent = target?.parentElement
+        const index = Array.from(parent?.children ?? []).indexOf(target) // Find the index of the current element among its siblings
+        const parentSibling = parent ? parent.nextElementSibling : null // Get the parent's next sibling
+        if (parentSibling && parentSibling.children.length > index) {
+            var nthChild = parentSibling.children[index] as HTMLElement | undefined // Find the nth child of the parent's sibling
+            if (nthChild) {
+                nthChild.focus() // Set focus on the nth child
+            }
+        }
+    }
+
+    static moveFocusToPreviousRow(target: HTMLElement) {
+        const parent = target?.parentElement
+        const index = Array.from(parent?.children ?? []).indexOf(target) // Find the index of the current element among its siblings
+        const parentSibling = parent ? parent.previousElementSibling : null // Get the parent's next sibling
+        if (parentSibling && parentSibling.children.length > index) {
+            var nthChild = parentSibling.children[index] as HTMLElement | undefined // Find the nth child of the parent's sibling
+            if (nthChild) {
+                nthChild.focus() // Set focus on the nth child
+            }
+        }
+    }
+
+    static onKeyDown(event: KeyboardEvent & { didCloseMenu?: boolean }) {
+        console.log('onKeyDown')
+        const self = event.currentTarget as MutableElement
+
+        // WARNING: the input's onBlur will NOT called
+        if (event.code === 'Escape') {
+            event.stopPropagation()
+            event.preventDefault()
+
+            // abort changes
+            self.isEditing = false
+            self.focus()
+        }
+
+        if (event.code === 'Enter' && self.isEditing && event.target instanceof HTMLElement) {
+            const target = event.target
+
+            // without this setTimeout, something sets `isEditing` back and re-renders immediately, negating the effect entirely
+            setTimeout(() => {
+                self.isEditing = false
+                self.focus()
+
+                // wait until the prev commands have processed
+                setTimeout(() => {
+                    MutableElement.moveFocusToNextRow(target)
+                }, 0)
+            })
+        }
+
+        if (event.code === 'Enter' && !self.isEditing && self.readonly) {
+            // we're using `contenteditable` to hold the value (when isEditing=fale)
+            // if this element receives `Enter`, it'll add them to the value, erroneously
+            // so we prevent that scenario right HERE.
+            event.preventDefault()
+        }
+
+        if (event.code === 'Enter' && !self.isEditing && !self.readonly) {
+            if (event.target instanceof HTMLElement && !self.isEditing) {
+                if (!event.didCloseMenu) self.isEditing = true
+            }
+        }
+
+        // set the value to `true` or `false` on `t` or `f`
+        if (self.type && BOOLEAN_TYPES.includes(self.type)) {
+            if (event.code === 'KeyT') {
+                self._value = true
+                self.requestUpdate('value')
+                return
+            } else if (event.code === 'KeyF') {
+                self._value = false
+                self.requestUpdate('value')
+                return
+            }
+        }
+    }
+
     protected override classMap() {
         return {
             'cursor-pointer': this.isInteractive && !this.readonly,
@@ -42,7 +122,7 @@ export class MutableElement extends ClassifiedElement {
     set value(newValue: Serializable) {
         const oldValue = this._value
         // convert strings to their proper value-types; json, boolean, number, and null
-        this._value = this.convertToType(newValue) ?? newValue
+        this._value = MutableElement.convertToType(this.type, newValue) ?? newValue
         this.requestUpdate('value', oldValue)
     }
 
@@ -55,7 +135,7 @@ export class MutableElement extends ClassifiedElement {
     set originalValue(newValue: Serializable) {
         const oldValue = this._originalValue
         // convert strings to their proper value-types; json, boolean, number, and null
-        this._originalValue = this.convertToType(newValue) ?? newValue
+        this._originalValue = MutableElement.convertToType(this.type, newValue) ?? newValue
         this.requestUpdate('originalValue', oldValue)
     }
 
@@ -127,78 +207,25 @@ export class MutableElement extends ClassifiedElement {
 
         if (changedProperties.has('type')) {
             const oldValue = this.value
-            this._value = this.convertToType(this.value) ?? this._value
+            this._value = MutableElement.convertToType(this.type, this.value) ?? this._value
             this.requestUpdate('value', oldValue)
 
             const oldOriginalValue = this.originalValue
-            this._originalValue = this.convertToType(this.originalValue) ?? this.originalValue
+            this._originalValue = MutableElement.convertToType(this.type, this.originalValue) ?? this.originalValue
             this.requestUpdate('originalValue', oldOriginalValue)
         }
     }
 
-    protected convertToType(newValue: Serializable) {
+    static convertToType(type: string | undefined, newValue: Serializable) {
         // convert strings to their proper value-types; json, boolean, number, and null
         const v = newValue
-        const t = this.type
+        const t = type
 
         if (t && typeof v === 'string') {
             if (NUMBER_TYPES.includes(t)) return parseInt(v, 10)
             if (JSON_TYPES.includes(t)) return JSON.parse(v)
             if (BOOLEAN_TYPES.includes(t)) return v.toLowerCase().trim() === 'true'
             if (v === '') return null
-        }
-    }
-
-    protected onKeyDown(event: KeyboardEvent & { didCloseMenu?: boolean }) {
-        // WARNING: the input's onBlur will NOT called
-        if (event.code === 'Escape') {
-            event.stopPropagation()
-            event.preventDefault()
-
-            // abort changes
-            this.isEditing = false
-            this.focus()
-        }
-
-        if (event.code === 'Enter' && this.isEditing && event.target instanceof HTMLElement) {
-            const target = event.target
-
-            // without this setTimeout, something sets `isEditing` back and re-renders immediately, negating the effect entirely
-            setTimeout(() => {
-                this.isEditing = false
-                this.focus()
-
-                // wait until the prev commands have processed
-                setTimeout(() => {
-                    this.moveFocusToNextRow(target)
-                }, 0)
-            })
-        }
-
-        if (event.code === 'Enter' && !this.isEditing && this.readonly) {
-            // we're using `contenteditable` to hold the value (when isEditing=fale)
-            // if this element receives `Enter`, it'll add them to the value, erroneously
-            // so we prevent that scenario right HERE.
-            event.preventDefault()
-        }
-
-        if (event.code === 'Enter' && !this.isEditing && !this.readonly) {
-            if (event.target instanceof HTMLElement && !this.isEditing) {
-                if (!event.didCloseMenu) this.isEditing = true
-            }
-        }
-
-        // set the value to `true` or `false` on `t` or `f`
-        if (this.type && BOOLEAN_TYPES.includes(this.type)) {
-            if (event.code === 'KeyT') {
-                this._value = true
-                this.requestUpdate('value')
-                return
-            } else if (event.code === 'KeyF') {
-                this._value = false
-                this.requestUpdate('value')
-                return
-            }
         }
     }
 
@@ -221,29 +248,5 @@ export class MutableElement extends ClassifiedElement {
 
     protected onBlur() {
         this.isEditing = false
-    }
-
-    protected moveFocusToNextRow(target: HTMLElement) {
-        const parent = target?.parentElement
-        const index = Array.from(parent?.children ?? []).indexOf(target) // Find the index of the current element among its siblings
-        const parentSibling = parent ? parent.nextElementSibling : null // Get the parent's next sibling
-        if (parentSibling && parentSibling.children.length > index) {
-            var nthChild = parentSibling.children[index] as HTMLElement | undefined // Find the nth child of the parent's sibling
-            if (nthChild) {
-                nthChild.focus() // Set focus on the nth child
-            }
-        }
-    }
-
-    protected moveFocusToPreviousRow(target: HTMLElement) {
-        const parent = target?.parentElement
-        const index = Array.from(parent?.children ?? []).indexOf(target) // Find the index of the current element among its siblings
-        const parentSibling = parent ? parent.previousElementSibling : null // Get the parent's next sibling
-        if (parentSibling && parentSibling.children.length > index) {
-            var nthChild = parentSibling.children[index] as HTMLElement | undefined // Find the nth child of the parent's sibling
-            if (nthChild) {
-                nthChild.focus() // Set focus on the nth child
-            }
-        }
     }
 }

--- a/src/components/mutable-element.ts
+++ b/src/components/mutable-element.ts
@@ -105,6 +105,19 @@ export class MutableElement extends ClassifiedElement {
         }
     }
 
+    static convertToType(type: string | undefined, newValue: Serializable) {
+        // convert strings to their proper value-types; json, boolean, number, and null
+        const v = newValue
+        const t = type
+
+        if (t && typeof v === 'string') {
+            if (NUMBER_TYPES.includes(t)) return parseInt(v, 10)
+            if (JSON_TYPES.includes(t)) return JSON.parse(v)
+            if (BOOLEAN_TYPES.includes(t)) return v.toLowerCase().trim() === 'true'
+            if (v === '') return null
+        }
+    }
+
     protected override classMap() {
         return {
             'cursor-pointer': this.isInteractive && !this.readonly,
@@ -219,25 +232,6 @@ export class MutableElement extends ClassifiedElement {
         }
     }
 
-    static convertToType(type: string | undefined, newValue: Serializable) {
-        // convert strings to their proper value-types; json, boolean, number, and null
-        const v = newValue
-        const t = type
-
-        if (t && typeof v === 'string') {
-            if (NUMBER_TYPES.includes(t)) return parseInt(v, 10)
-            if (JSON_TYPES.includes(t)) return JSON.parse(v)
-            if (BOOLEAN_TYPES.includes(t)) return v.toLowerCase().trim() === 'true'
-            if (v === '') return null
-        }
-    }
-
-    protected onChange(event: Event) {
-        const { value } = event.target as HTMLInputElement
-        if (value === '') this.value = null
-        else this.value = value
-    }
-
     protected dispatchChangedEvent() {
         this.dispatchEvent(
             new CellUpdateEvent({
@@ -251,5 +245,11 @@ export class MutableElement extends ClassifiedElement {
 
     protected onBlur() {
         this.isEditing = false
+    }
+
+    protected onChange(event: Event) {
+        const { value } = event.target as HTMLInputElement
+        if (value === '') this.value = null
+        else this.value = value
     }
 }

--- a/src/components/table/td.ts
+++ b/src/components/table/td.ts
@@ -263,9 +263,6 @@ export class TableData extends MutableElement {
     @property({ type: Boolean, attribute: 'draw-right-border' })
     public _drawRightBorder = false
 
-    @property({ type: Boolean, attribute: 'menu' })
-    public hasMenu = false
-
     @property({ type: Boolean, attribute: 'row-selector' })
     public isRowSelector = false
 
@@ -452,7 +449,6 @@ export class TableData extends MutableElement {
                           theme=${this.theme}
                           .options=${menuOptions}
                           ?without-padding=${!!this.plugin}
-                          ?menu=${this.hasMenu}
                           ?selectable-text=${!this.isInteractive}
                           @menu-selection=${this.onMenuSelection}
                           ><span class=${contentWrapperClass}>${cellContents}</span

--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -352,7 +352,7 @@ export class TH extends MutableElement {
             return html`<div class=${classMap(blankElementClasses)}><slot></slot></div> `
         } else {
             const body = this.isEditing
-                ? html`<input .value=${this.value} @input=${this.onChange} @keydown=${this.onKeyDown} class=${classMap({
+                ? html`<input .value=${this.value} @input=${this.onChange} @keydown=${MutableElement.onKeyDown} class=${classMap({
                       'z-[1] absolute top-0 bottom-0 right-0 left-0': true,
                       'bg-blue-50 dark:bg-blue-950 outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-700': true,
                       'px-cell-padding-x font-normal': true,

--- a/src/components/table/th.ts
+++ b/src/components/table/th.ts
@@ -60,9 +60,6 @@ export class TH extends MutableElement {
     @property({ attribute: 'is-last', type: Boolean })
     protected isLastColumn = false
 
-    @property({ attribute: 'menu', type: Boolean })
-    public hasMenu = false
-
     @property({ attribute: 'options', type: Array })
     public options: HeaderMenuOptions = [
         {


### PR DESCRIPTION
- My goal is to reduce memory consumption (think thousands of cells each with their own copies of all these functions)
- Next step is to (attempt?) to remove a lot of event listeners and instead have few/single handlers. For example, instead of every cell having a click handler, the table itself can have a click handler, and on click, it determines which cell was selected and proceeds from there